### PR TITLE
Fix "Edit this page" links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,7 +28,7 @@ module.exports={
         "docs": {
           "showLastUpdateAuthor": true,
           "showLastUpdateTime": true,
-          "editUrl": "https://github.com/Nanopublication/nanopub-website/edit/main/website/",
+          "editUrl": "https://github.com/Nanopublication/nanopub-website/edit/main/",
           "path": "./docs",
           "breadcrumbs": false,
           "sidebarPath": require.resolve('./sidebars.json')


### PR DESCRIPTION
Currently if you click on an "Edit this page" link on the website, you get a 404 error on GitHub.

The `/website` part is not needed, as this directory does not exist in the repo.